### PR TITLE
when displaying markdown, it fixes the error message: ValueError: Cannot process flags argument with a compiled pattern

### DIFF
--- a/0.11/Markdown/macro.py
+++ b/0.11/Markdown/macro.py
@@ -24,10 +24,8 @@ from StringIO import StringIO
 
 # links, autolinks, and reference-style links
 
-LINK = compile(
-    r'(\]\()([^) ]+)([^)]*\))|(<)([^>]+)(>)|(\n\[[^]]+\]: *)([^ \n]+)(.*\n)'
-)
-HREF = compile(r'href=[\'"]?([^\'" ]*)')
+LINK = r'(\]\()([^) ]+)([^)]*\))|(<)([^>]+)(>)|(\n\[[^]]+\]: *)([^ \n]+)(.*\n)'                                                           
+HREF = r'href=[\'"]?([^\'" ]*)'   
 
 __all__ = ['MarkdownMacro']
 


### PR DESCRIPTION
As described in [ValueError: Cannot process flags argument with a compiled pattern (when displaying markdown)](http://trac-hacks.org/ticket/9157)
